### PR TITLE
Fix the paths to the wibotic antenna mesh

### DIFF
--- a/urdf/husky_observer.urdf.xacro
+++ b/urdf/husky_observer.urdf.xacro
@@ -78,14 +78,14 @@
   <link name="charger_mount_link">
     <visual>
       <geometry>
-        <mesh filename="package://husky_observer_description/meshes/wibotic.stl" />
+        <mesh filename="package://cpr_onav_description/meshes/wibotic.stl" />
       </geometry>
       <material name="black" />
       <origin xyz="0 0 0" rpy="0 0 0" />
     </visual>
     <collision>
       <geometry>
-        <mesh filename="package://husky_observer_description/meshes/wibotic.stl" />
+        <mesh filename="package://cpr_onav_description/meshes/wibotic.stl" />
       </geometry>
       <origin xyz="0 0 0" rpy="0 0 0" />
     </collision>


### PR DESCRIPTION
The paths mistakenly point to the husky_observer_description package, not cpr_onav_description