### PR TITLE
Fix the position of the rear lidar

### DIFF
--- a/urdf/outdoornav_description.urdf.xacro
+++ b/urdf/outdoornav_description.urdf.xacro
@@ -161,7 +161,7 @@
       </xacro:hokuyo_ust10_mount>
       <xacro:if value="$(arg rear_hokuyo_enable)">
         <xacro:hokuyo_ust10_mount prefix="rear" parent_link="base_link" topic="/sensors/lidar_$(arg rear_hokuyo_num)/scan">
-            <origin xyz="$(arg hokuyo_xyz)" rpy="$(arg hokuyo_rpy)" />
+            <origin xyz="$(arg rear_hokuyo_xyz)" rpy="$(arg rear_hokuyo_rpy)" />
         </xacro:hokuyo_ust10_mount>
       </xacro:if>
 


### PR DESCRIPTION
Copy-and-paste error in the rear lidar position; the two lidars incorrectly use the same XYZ and RPY argument