### PR TITLE
Add the name prefix to the kinect controller plugin name

### DIFF
--- a/urdf/accessories/d435_gazebo.urdf.xacro
+++ b/urdf/accessories/d435_gazebo.urdf.xacro
@@ -32,7 +32,7 @@
             <far>50.0</far>
           </clip>
         </camera>
-        <plugin name="kinect_controller" filename="libgazebo_ros_openni_kinect.so">
+        <plugin name="${name}_kinect_controller" filename="libgazebo_ros_openni_kinect.so">
           <baseline>0.2</baseline>
           <alwaysOn>true</alwaysOn>
           <updateRate>30</updateRate>


### PR DESCRIPTION
This fixes a bug where dual RealSenses would have conflicting controllers loaded