### PR TITLE
Reduce RealSense simulation FPS to 6

### DIFF
--- a/urdf/accessories/d435_gazebo.urdf.xacro
+++ b/urdf/accessories/d435_gazebo.urdf.xacro
@@ -15,7 +15,7 @@
     <gazebo reference="${name}_link">
       <turnGravityOff>true</turnGravityOff>
       <sensor type="depth" name="${name}_depth_sensor">
-        <update_rate>30</update_rate>
+        <update_rate>6</update_rate>
         <camera>
           <!-- 75x65 degree FOV for the depth sensor -->
           <horizontal_fov>1.5184351666666667</horizontal_fov>
@@ -35,7 +35,7 @@
         <plugin name="${name}_kinect_controller" filename="libgazebo_ros_openni_kinect.so">
           <baseline>0.2</baseline>
           <alwaysOn>true</alwaysOn>
-          <updateRate>30</updateRate>
+          <updateRate>6</updateRate>
           <cameraName>/sensors/stereo_${topic_n}</cameraName>
           <imageTopicName>image_raw</imageTopicName>
           <cameraInfoTopicName>camera_info</cameraInfoTopicName>


### PR DESCRIPTION
Reduce the target FPS of the RealSense simulations to 6FPS, to match with physical hardware configuration