### PR TITLE
Add the top-down SVGs for Husky Observer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,6 @@ find_package(catkin REQUIRED)
 catkin_package()
 
 install(
-  DIRECTORY config launch meshes scripts urdf
+  DIRECTORY assets config launch meshes scripts urdf
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/assets/husky_observer_detailed.svg
+++ b/assets/husky_observer_detailed.svg
@@ -1,0 +1,403 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="230"
+   height="230"
+   viewBox="0 0 60.854166 60.854165"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="husky_observer_detailed.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.5853923"
+     inkscape:cx="29.806686"
+     inkscape:cy="58.444673"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-18.823296,-219.45057)">
+    <g
+       id="g2234"
+       transform="translate(18.847681,-15.570952)"
+       inkscape:export-xdpi="27.41"
+       inkscape:export-ydpi="27.41">
+      <g
+         transform="translate(3.3172408e-7,-0.90454683)"
+         id="g2166">
+        <rect
+           style="fill:#1d1d1d;fill-opacity:1;stroke:none;stroke-width:11.2157526;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect1049"
+           width="3.1527033"
+           height="1.327454"
+           x="28.850731"
+           y="251.49702" />
+        <g
+           id="g2130">
+          <g
+             transform="matrix(-0.98859639,0,0,-1.0673513,60.539689,552.93401)"
+             id="g1028-3">
+            <g
+               id="g1004-6"
+               transform="translate(-0.12934546,0.56049699)">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path985-75"
+                 d="m 37.185923,278.76187 -1.120992,0.81919 h -5.475626"
+                 style="fill:none;stroke:#1a1a1a;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path985-7-3"
+                 d="m 23.992687,278.76187 1.120991,0.81919 h 5.475627"
+                 style="fill:none;stroke:#1a1a1a;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            </g>
+            <path
+               style="fill:none;stroke:#1d1d1d;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 27.636814,278.5036 v 1.59527"
+               id="path1006-5"
+               inkscape:connector-curvature="0" />
+            <path
+               style="fill:none;stroke:#1d1d1d;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 33.284898,278.56827 v 1.59527"
+               id="path1006-9-6"
+               inkscape:connector-curvature="0" />
+          </g>
+          <g
+             transform="translate(-0.07025167)"
+             id="g2118">
+            <path
+               style="fill:none;stroke:#1d1d1d;stroke-width:0.41088775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 33.300848,254.29848 v -1.70271"
+               id="path1006-5-7"
+               inkscape:connector-curvature="0" />
+            <path
+               style="fill:none;stroke:#1d1d1d;stroke-width:0.41088775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 27.693822,254.29848 v -1.70271"
+               id="path1006-9-6-0"
+               inkscape:connector-curvature="0" />
+          </g>
+          <path
+             inkscape:connector-curvature="0"
+             id="path1006-9-6-0-9"
+             d="M 33.230596,252.59577 H 27.62357"
+             style="fill:none;stroke:#1d1d1d;stroke-width:0.38263318;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.98859638,0,0,1.0673513,0.48762867,-18.97156)"
+         id="g1028">
+        <g
+           id="g1004"
+           transform="translate(-0.12934546,0.56049699)">
+          <path
+             inkscape:connector-curvature="0"
+             id="path985"
+             d="m 37.185923,278.76187 -1.120992,0.81919 h -5.475626"
+             style="fill:none;stroke:#1a1a1a;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path985-7"
+             d="m 23.992687,278.76187 1.120991,0.81919 h 5.475627"
+             style="fill:none;stroke:#1a1a1a;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <path
+           style="fill:none;stroke:#1d1d1d;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 27.636814,278.5036 v 1.59527"
+           id="path1006"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:#1d1d1d;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 33.284898,278.56827 v 1.59527"
+           id="path1006-9"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="translate(1.3833332e-7,-0.33393738)"
+         id="g2152">
+        <g
+           id="g890"
+           transform="matrix(0.98859638,0,0,1.0673513,0.46493739,-18.727881)">
+          <rect
+             y="256.68805"
+             x="20.855688"
+             height="8.6221561"
+             width="3.1599524"
+             id="rect846"
+             style="fill:#292929;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path848"
+             d="m 21.095079,256.92744 2.664157,2.66416"
+             style="fill:none;stroke:#000000;stroke-width:0.43580183;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path848-3"
+             d="m 21.091123,259.64751 2.664157,2.66416"
+             style="fill:none;stroke:#000000;stroke-width:0.43580183;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path848-6"
+             d="m 21.075879,262.40659 2.664157,2.66416"
+             style="fill:none;stroke:#000000;stroke-width:0.43580183;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <g
+           transform="matrix(0.98859638,0,0,1.0673513,0.46493739,-4.6139134)"
+           id="g890-5">
+          <rect
+             y="256.68805"
+             x="20.855688"
+             height="8.6221561"
+             width="3.1599524"
+             id="rect846-3"
+             style="fill:#292929;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path848-5"
+             d="m 21.095079,256.92744 2.664157,2.66416"
+             style="fill:none;stroke:#000000;stroke-width:0.43580183;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path848-3-6"
+             d="m 21.091123,259.64751 2.664157,2.66416"
+             style="fill:none;stroke:#000000;stroke-width:0.43580183;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path848-6-2"
+             d="m 21.075879,262.40659 2.664157,2.66416"
+             style="fill:none;stroke:#000000;stroke-width:0.43580183;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <g
+           transform="matrix(-0.98859638,0,0,1.0673513,60.389228,-18.727881)"
+           id="g890-9">
+          <rect
+             y="256.68805"
+             x="20.855688"
+             height="8.6221561"
+             width="3.1599524"
+             id="rect846-1"
+             style="fill:#292929;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path848-2"
+             d="m 21.095079,256.92744 2.664157,2.66416"
+             style="fill:none;stroke:#000000;stroke-width:0.43580183;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path848-3-7"
+             d="m 21.091123,259.64751 2.664157,2.66416"
+             style="fill:none;stroke:#000000;stroke-width:0.43580183;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path848-6-0"
+             d="m 21.075879,262.40659 2.664157,2.66416"
+             style="fill:none;stroke:#000000;stroke-width:0.43580183;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <g
+           transform="matrix(-0.98859638,0,0,1.0673513,60.389229,-4.6139199)"
+           id="g890-93">
+          <rect
+             y="256.68805"
+             x="20.855688"
+             height="8.6221561"
+             width="3.1599524"
+             id="rect846-6"
+             style="fill:#292929;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path848-0"
+             d="m 21.095079,256.92744 2.664157,2.66416"
+             style="fill:none;stroke:#000000;stroke-width:0.43580183;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path848-3-62"
+             d="m 21.091123,259.64751 2.664157,2.66416"
+             style="fill:none;stroke:#000000;stroke-width:0.43580183;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path848-6-6"
+             d="m 21.075879,262.40659 2.664157,2.66416"
+             style="fill:none;stroke:#000000;stroke-width:0.43580183;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+      </g>
+      <g
+         transform="matrix(1,0,0,1.0918316,-0.25695932,-24.88971)"
+         id="g2046">
+        <g
+           id="g2007">
+          <rect
+             y="258.34756"
+             x="23.953232"
+             height="3.8343484"
+             width="13.453835"
+             id="rect848-3-8"
+             style="fill:#cccc00;fill-opacity:1;stroke:none;stroke-width:0.09487421;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <rect
+             y="255.91629"
+             x="24.887096"
+             height="2.7127104"
+             width="11.536195"
+             id="rect848-3"
+             style="fill:#cccc00;fill-opacity:1;stroke:none;stroke-width:0.07389454;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        </g>
+        <g
+           transform="matrix(1,0,0,-1,-0.02445411,533.89669)"
+           id="g2007-7">
+          <rect
+             y="258.34756"
+             x="23.953232"
+             height="3.8343484"
+             width="13.453835"
+             id="rect848-3-8-9"
+             style="fill:#cccc00;fill-opacity:1;stroke:none;stroke-width:0.09487421;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <rect
+             y="255.91629"
+             x="24.887096"
+             height="2.7127104"
+             width="11.536195"
+             id="rect848-3-2"
+             style="fill:#cccc00;fill-opacity:1;stroke:none;stroke-width:0.07389454;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        </g>
+        <g
+           id="g1988">
+          <rect
+             y="259.51263"
+             x="24.609367"
+             height="14.893085"
+             width="12.173804"
+             id="rect1927"
+             style="fill:#1d1d1d;fill-opacity:1;stroke:none;stroke-width:0.39616865;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <g
+             transform="matrix(1,0,0,1.0499302,5.0234163,-7.1070493)"
+             id="g1953">
+            <path
+               style="fill:#a3a300;fill-opacity:1;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 19.863681,250.51507 h 1.157206 l -1.434935,3.42533 h -1.620088 z"
+               id="path1929"
+               inkscape:connector-curvature="0" />
+            <rect
+               style="fill:#8c8c00;fill-opacity:1;stroke:none;stroke-width:0.28892019;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               id="rect1931"
+               width="1.5956317"
+               height="14.164198"
+               x="17.965864"
+               y="253.9404" />
+            <path
+               style="fill:#a3a300;fill-opacity:1;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 19.839226,271.52991 h 1.157206 l -1.434935,-3.42533 h -1.620088 z"
+               id="path1929-6"
+               inkscape:connector-curvature="0" />
+          </g>
+          <g
+             transform="matrix(-1,0,0,1.0499302,56.344669,-7.1070598)"
+             id="g1953-0">
+            <path
+               style="fill:#a3a300;fill-opacity:1;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 19.863681,250.51507 h 1.157206 l -1.434935,3.42533 h -1.620088 z"
+               id="path1929-62"
+               inkscape:connector-curvature="0" />
+            <rect
+               style="fill:#8c8c00;fill-opacity:1;stroke:none;stroke-width:0.28892019;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               id="rect1931-6"
+               width="1.5956317"
+               height="14.164198"
+               x="17.965864"
+               y="253.9404" />
+            <path
+               style="fill:#a3a300;fill-opacity:1;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 19.839226,271.52991 h 1.157206 l -1.434935,-3.42533 h -1.620088 z"
+               id="path1929-6-1"
+               inkscape:connector-curvature="0" />
+          </g>
+        </g>
+      </g>
+      <g
+         transform="translate(-0.02438471,7.2508238)"
+         id="g2054">
+        <rect
+           style="fill:#171717;fill-opacity:1;stroke:none;stroke-width:0.24711376;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect2048"
+           width="17.548208"
+           height="1.4472749"
+           x="21.652979"
+           y="265.84927" />
+        <g
+           id="g1925"
+           transform="translate(-0.12314765,-1.3678385e-5)">
+          <circle
+             r="2.044028"
+             cy="266.57294"
+             cx="21.014856"
+             id="path1087"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.77464426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <circle
+             r="2.044028"
+             cy="266.57294"
+             cx="40.085606"
+             id="path1087-3"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.77464426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        </g>
+      </g>
+      <g
+         transform="translate(-3.3306042,6.6955233)"
+         id="g2104">
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#7b7b7b;fill-opacity:1;stroke:none;stroke-width:0.37172958;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 33.757688,257.21813 a 9.8414697,2.6593676 0 0 0 -4.414201,0.28319 v 4.74958 a 9.8414697,2.6593676 0 0 0 4.414201,0.28577 9.8414697,2.6593676 0 0 0 4.4142,-0.28319 v -4.74958 a 9.8414697,2.6593676 0 0 0 -4.4142,-0.28577 z"
+           id="path2056-0" />
+        <path
+           style="fill:#949494;fill-opacity:1;stroke:none;stroke-width:0.37172958;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 29.405499,257.49357 a 9.8414696,2.6593675 0 0 0 -0.06201,0.008 v 4.74958 a 9.8414696,2.6593675 0 0 0 0.241846,0.0289 2.6412766,2.4060941 0 0 0 2.329056,-2.38642 2.6412766,2.4060941 0 0 0 -2.50889,-2.39985 z"
+           id="path2056"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:#949494;fill-opacity:1;stroke:none;stroke-width:0.37172958;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 38.109878,257.4959 a 9.8414697,2.6593676 0 0 1 0.06201,0.008 v 4.74958 a 9.8414697,2.6593676 0 0 1 -0.241846,0.0289 2.6412766,2.4060941 0 0 1 -2.329056,-2.38642 2.6412766,2.4060941 0 0 1 2.50889,-2.39985 z"
+           id="path2056-2"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/assets/husky_observer_lights_detailed.svg
+++ b/assets/husky_observer_lights_detailed.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="230"
+   height="230"
+   viewBox="0 0 60.854167 60.854165"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="husky_lights_detailed.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2150"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#ffffff;stroke-width:1pt;stroke-opacity:1;fill:#ffffff;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lstart-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1241"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.244946"
+     inkscape:cx="94.409532"
+     inkscape:cy="132.37871"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-236.14584)">
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Lstart-3)"
+       d="m 30.427083,255.30886 v 23.04177"
+       id="path1239"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/assets/husky_observer_lights_normal.svg
+++ b/assets/husky_observer_lights_normal.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="230"
+   height="230"
+   viewBox="0 0 60.854167 60.854165"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="husky_lights_normal.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2150"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#ffffff;stroke-width:1pt;stroke-opacity:1;fill:#ffffff;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lstart-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1241"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.244946"
+     inkscape:cx="94.409532"
+     inkscape:cy="109.05026"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-236.14584)">
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.52916667;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Lstart-3)"
+       d="m 30.427083,255.30886 v 23.04177"
+       id="path1239"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/assets/husky_observer_lights_simple.svg
+++ b/assets/husky_observer_lights_simple.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="230"
+   height="230"
+   viewBox="0 0 60.854167 60.854165"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="husky_lights_simple.svg">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path2150"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#ffffff;stroke-width:1pt;stroke-opacity:1;fill:#ffffff;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lstart-3"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1241"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:#fcfcfc;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.244946"
+     inkscape:cx="94.409532"
+     inkscape:cy="109.05026"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-236.14584)">
+    <path
+       style="fill:none;stroke:#fcfcfc;stroke-width:0.79375;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Lstart-3)"
+       d="m 30.427083,255.30886 v 23.04177"
+       id="path1239"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/assets/husky_observer_normal.svg
+++ b/assets/husky_observer_normal.svg
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="230"
+   height="230"
+   viewBox="0 0 60.854166 60.854165"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="husky_normal.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.5251484"
+     inkscape:cx="74.991678"
+     inkscape:cy="80.838796"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-18.823296,-219.45057)">
+    <g
+       id="g5514">
+      <g
+         transform="translate(18.847681,-16.475499)"
+         id="g2166">
+        <rect
+           style="fill:#1d1d1d;fill-opacity:1;stroke:none;stroke-width:11.2157526;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect1049"
+           width="3.1527033"
+           height="1.327454"
+           x="28.850731"
+           y="251.49702" />
+        <g
+           id="g2130">
+          <g
+             transform="matrix(-0.98859639,0,0,-1.0673513,60.539689,552.93401)"
+             id="g1028-3">
+            <g
+               id="g1004-6"
+               transform="translate(-0.12934546,0.56049699)">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path985-75"
+                 d="m 37.185923,278.76187 -1.120992,0.81919 h -5.475626"
+                 style="fill:none;stroke:#1a1a1a;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path985-7-3"
+                 d="m 23.992687,278.76187 1.120991,0.81919 h 5.475627"
+                 style="fill:none;stroke:#1a1a1a;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            </g>
+            <path
+               style="fill:none;stroke:#1d1d1d;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 27.636814,278.5036 v 1.59527"
+               id="path1006-5"
+               inkscape:connector-curvature="0" />
+            <path
+               style="fill:none;stroke:#1d1d1d;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 33.284898,278.56827 v 1.59527"
+               id="path1006-9-6"
+               inkscape:connector-curvature="0" />
+          </g>
+          <g
+             transform="translate(-0.07025167)"
+             id="g2118">
+            <path
+               style="fill:none;stroke:#1d1d1d;stroke-width:0.41088775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 33.300848,254.29848 v -1.70271"
+               id="path1006-5-7"
+               inkscape:connector-curvature="0" />
+            <path
+               style="fill:none;stroke:#1d1d1d;stroke-width:0.41088775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 27.693822,254.29848 v -1.70271"
+               id="path1006-9-6-0"
+               inkscape:connector-curvature="0" />
+          </g>
+          <path
+             inkscape:connector-curvature="0"
+             id="path1006-9-6-0-9"
+             d="M 33.230596,252.59577 H 27.62357"
+             style="fill:none;stroke:#1d1d1d;stroke-width:0.38263318;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+      </g>
+      <g
+         transform="matrix(0.98859638,0,0,1.0673513,19.33531,-34.542512)"
+         id="g1028">
+        <g
+           id="g1004"
+           transform="translate(-0.12934546,0.56049699)">
+          <path
+             inkscape:connector-curvature="0"
+             id="path985"
+             d="m 37.185923,278.76187 -1.120992,0.81919 h -5.475626"
+             style="fill:none;stroke:#1a1a1a;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path985-7"
+             d="m 23.992687,278.76187 1.120991,0.81919 h 5.475627"
+             style="fill:none;stroke:#1a1a1a;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <path
+           style="fill:none;stroke:#1d1d1d;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 27.636814,278.5036 v 1.59527"
+           id="path1006"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:none;stroke:#1d1d1d;stroke-width:0.40000001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 33.284898,278.56827 v 1.59527"
+           id="path1006-9"
+           inkscape:connector-curvature="0" />
+      </g>
+      <rect
+         y="239.34355"
+         x="39.930477"
+         height="9.2028694"
+         width="3.1239176"
+         id="rect846"
+         style="fill:#292929;fill-opacity:1;stroke:none;stroke-width:0.51360971;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="253.45752"
+         x="39.930477"
+         height="9.2028694"
+         width="3.1239176"
+         id="rect846-3"
+         style="fill:#292929;fill-opacity:1;stroke:none;stroke-width:0.51360971;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         transform="scale(-1,1)"
+         y="239.34355"
+         x="-58.619053"
+         height="9.2028694"
+         width="3.1239176"
+         id="rect846-1"
+         style="fill:#292929;fill-opacity:1;stroke:none;stroke-width:0.51360971;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         transform="scale(-1,1)"
+         y="253.45752"
+         x="-58.619053"
+         height="9.2028694"
+         width="3.1239176"
+         id="rect846-6"
+         style="fill:#292929;fill-opacity:1;stroke:none;stroke-width:0.51360971;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <g
+         transform="matrix(1,0,0,1.0918316,18.590722,-40.460662)"
+         id="g2046">
+        <g
+           id="g2007">
+          <rect
+             y="258.34756"
+             x="23.953232"
+             height="3.8343484"
+             width="13.453835"
+             id="rect848-3-8"
+             style="fill:#cccc00;fill-opacity:1;stroke:none;stroke-width:0.09487421;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <rect
+             y="255.91629"
+             x="24.887096"
+             height="2.7127104"
+             width="11.536195"
+             id="rect848-3"
+             style="fill:#cccc00;fill-opacity:1;stroke:none;stroke-width:0.07389454;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        </g>
+        <g
+           transform="matrix(1,0,0,-1,-0.02445411,533.89669)"
+           id="g2007-7">
+          <rect
+             y="258.34756"
+             x="23.953232"
+             height="3.8343484"
+             width="13.453835"
+             id="rect848-3-8-9"
+             style="fill:#cccc00;fill-opacity:1;stroke:none;stroke-width:0.09487421;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <rect
+             y="255.91629"
+             x="24.887096"
+             height="2.7127104"
+             width="11.536195"
+             id="rect848-3-2"
+             style="fill:#cccc00;fill-opacity:1;stroke:none;stroke-width:0.07389454;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        </g>
+        <g
+           id="g1988">
+          <rect
+             y="259.51263"
+             x="24.609367"
+             height="14.893085"
+             width="12.173804"
+             id="rect1927"
+             style="fill:#1d1d1d;fill-opacity:1;stroke:none;stroke-width:0.39616865;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <g
+             transform="matrix(1,0,0,1.0499302,5.0234163,-7.1070493)"
+             id="g1953">
+            <path
+               style="fill:#a3a300;fill-opacity:1;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 19.863681,250.51507 h 1.157206 l -1.434935,3.42533 h -1.620088 z"
+               id="path1929"
+               inkscape:connector-curvature="0" />
+            <rect
+               style="fill:#8c8c00;fill-opacity:1;stroke:none;stroke-width:0.28892019;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               id="rect1931"
+               width="1.5956317"
+               height="14.164198"
+               x="17.965864"
+               y="253.9404" />
+            <path
+               style="fill:#a3a300;fill-opacity:1;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 19.839226,271.52991 h 1.157206 l -1.434935,-3.42533 h -1.620088 z"
+               id="path1929-6"
+               inkscape:connector-curvature="0" />
+          </g>
+          <g
+             transform="matrix(-1,0,0,1.0499302,56.344669,-7.1070598)"
+             id="g1953-0">
+            <path
+               style="fill:#a3a300;fill-opacity:1;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 19.863681,250.51507 h 1.157206 l -1.434935,3.42533 h -1.620088 z"
+               id="path1929-62"
+               inkscape:connector-curvature="0" />
+            <rect
+               style="fill:#8c8c00;fill-opacity:1;stroke:none;stroke-width:0.28892019;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+               id="rect1931-6"
+               width="1.5956317"
+               height="14.164198"
+               x="17.965864"
+               y="253.9404" />
+            <path
+               style="fill:#a3a300;fill-opacity:1;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+               d="m 19.839226,271.52991 h 1.157206 l -1.434935,-3.42533 h -1.620088 z"
+               id="path1929-6-1"
+               inkscape:connector-curvature="0" />
+          </g>
+        </g>
+      </g>
+      <g
+         transform="translate(18.823296,-8.3201282)"
+         id="g2054">
+        <rect
+           style="fill:#171717;fill-opacity:1;stroke:none;stroke-width:0.24711376;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect2048"
+           width="17.548208"
+           height="1.4472749"
+           x="21.652979"
+           y="265.84927" />
+        <g
+           id="g1925"
+           transform="translate(-0.12314765,-1.3678385e-5)">
+          <circle
+             r="2.044028"
+             cy="266.57294"
+             cx="21.014856"
+             id="path1087"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.77464426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <circle
+             r="2.044028"
+             cy="266.57294"
+             cx="40.085606"
+             id="path1087-3"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.77464426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        </g>
+      </g>
+      <g
+         transform="translate(15.517077,-8.8754287)"
+         id="g2104">
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#7b7b7b;fill-opacity:1;stroke:none;stroke-width:0.37172958;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 33.757688,257.21813 a 9.8414697,2.6593676 0 0 0 -4.414201,0.28319 v 4.74958 a 9.8414697,2.6593676 0 0 0 4.414201,0.28577 9.8414697,2.6593676 0 0 0 4.4142,-0.28319 v -4.74958 a 9.8414697,2.6593676 0 0 0 -4.4142,-0.28577 z"
+           id="path2056-0" />
+        <path
+           style="fill:#949494;fill-opacity:1;stroke:none;stroke-width:0.37172958;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 29.405499,257.49357 a 9.8414696,2.6593675 0 0 0 -0.06201,0.008 v 4.74958 a 9.8414696,2.6593675 0 0 0 0.241846,0.0289 2.6412766,2.4060941 0 0 0 2.329056,-2.38642 2.6412766,2.4060941 0 0 0 -2.50889,-2.39985 z"
+           id="path2056"
+           inkscape:connector-curvature="0" />
+        <path
+           style="fill:#949494;fill-opacity:1;stroke:none;stroke-width:0.37172958;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 38.109878,257.4959 a 9.8414697,2.6593676 0 0 1 0.06201,0.008 v 4.74958 a 9.8414697,2.6593676 0 0 1 -0.241846,0.0289 2.6412766,2.4060941 0 0 1 -2.329056,-2.38642 2.6412766,2.4060941 0 0 1 2.50889,-2.39985 z"
+           id="path2056-2"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/assets/husky_observer_simple.svg
+++ b/assets/husky_observer_simple.svg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="230"
+   height="230"
+   viewBox="0 0 60.854166 60.854165"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="husky_simple.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.5251484"
+     inkscape:cx="74.991678"
+     inkscape:cy="80.838796"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-18.823296,-219.45057)">
+    <rect
+       style="fill:#292929;fill-opacity:1;stroke:none;stroke-width:0.51360971;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect846"
+       width="3.1239176"
+       height="9.2028694"
+       x="39.930477"
+       y="239.34355" />
+    <rect
+       style="fill:#292929;fill-opacity:1;stroke:none;stroke-width:0.51360971;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect846-3"
+       width="3.1239176"
+       height="9.2028694"
+       x="39.930477"
+       y="253.45752" />
+    <rect
+       style="fill:#292929;fill-opacity:1;stroke:none;stroke-width:0.51360971;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect846-1"
+       width="3.1239176"
+       height="9.2028694"
+       x="-58.619053"
+       y="239.34355"
+       transform="scale(-1,1)" />
+    <rect
+       style="fill:#292929;fill-opacity:1;stroke:none;stroke-width:0.51360971;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect846-6"
+       width="3.1239176"
+       height="9.2028694"
+       x="-58.619053"
+       y="253.45752"
+       transform="scale(-1,1)" />
+    <g
+       id="g2046"
+       transform="matrix(1,0,0,1.0918316,18.590722,-40.460662)">
+      <g
+         id="g2007">
+        <rect
+           style="fill:#cccc00;fill-opacity:1;stroke:none;stroke-width:0.09487421;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect848-3-8"
+           width="13.453835"
+           height="3.8343484"
+           x="23.953232"
+           y="258.34756" />
+        <rect
+           style="fill:#cccc00;fill-opacity:1;stroke:none;stroke-width:0.07389454;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect848-3"
+           width="11.536195"
+           height="2.7127104"
+           x="24.887096"
+           y="255.91629" />
+      </g>
+      <g
+         id="g2007-7"
+         transform="matrix(1,0,0,-1,-0.02445411,533.89669)">
+        <rect
+           style="fill:#cccc00;fill-opacity:1;stroke:none;stroke-width:0.09487421;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect848-3-8-9"
+           width="13.453835"
+           height="3.8343484"
+           x="23.953232"
+           y="258.34756" />
+        <rect
+           style="fill:#cccc00;fill-opacity:1;stroke:none;stroke-width:0.07389454;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect848-3-2"
+           width="11.536195"
+           height="2.7127104"
+           x="24.887096"
+           y="255.91629" />
+      </g>
+      <g
+         id="g1988">
+        <rect
+           style="fill:#1d1d1d;fill-opacity:1;stroke:none;stroke-width:0.39616865;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect1927"
+           width="12.173804"
+           height="14.893085"
+           x="24.609367"
+           y="259.51263" />
+        <g
+           id="g1953"
+           transform="matrix(1,0,0,1.0499302,5.0234163,-7.1070493)">
+          <path
+             inkscape:connector-curvature="0"
+             id="path1929"
+             d="m 19.863681,250.51507 h 1.157206 l -1.434935,3.42533 h -1.620088 z"
+             style="fill:#a3a300;fill-opacity:1;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             y="253.9404"
+             x="17.965864"
+             height="14.164198"
+             width="1.5956317"
+             id="rect1931"
+             style="fill:#8c8c00;fill-opacity:1;stroke:none;stroke-width:0.28892019;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path1929-6"
+             d="m 19.839226,271.52991 h 1.157206 l -1.434935,-3.42533 h -1.620088 z"
+             style="fill:#a3a300;fill-opacity:1;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <g
+           id="g1953-0"
+           transform="matrix(-1,0,0,1.0499302,56.344669,-7.1070598)">
+          <path
+             inkscape:connector-curvature="0"
+             id="path1929-62"
+             d="m 19.863681,250.51507 h 1.157206 l -1.434935,3.42533 h -1.620088 z"
+             style="fill:#a3a300;fill-opacity:1;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <rect
+             y="253.9404"
+             x="17.965864"
+             height="14.164198"
+             width="1.5956317"
+             id="rect1931-6"
+             style="fill:#8c8c00;fill-opacity:1;stroke:none;stroke-width:0.28892019;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path1929-6-1"
+             d="m 19.839226,271.52991 h 1.157206 l -1.434935,-3.42533 h -1.620088 z"
+             style="fill:#a3a300;fill-opacity:1;stroke:none;stroke-width:0.26499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+      </g>
+    </g>
+    <g
+       id="g1925"
+       transform="translate(18.700148,-8.3201419)">
+      <circle
+         r="2.044028"
+         cy="266.57294"
+         cx="21.014856"
+         id="path1087"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.77464426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <circle
+         r="2.044028"
+         cy="266.57294"
+         cx="40.085606"
+         id="path1087-3"
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.77464426;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#7b7b7b;fill-opacity:1;stroke:none;stroke-width:0.37172958;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 49.274765,248.3427 a 9.8414697,2.6593676 0 0 0 -4.414201,0.28319 v 4.74958 a 9.8414697,2.6593676 0 0 0 4.414201,0.28577 9.8414697,2.6593676 0 0 0 4.4142,-0.28319 v -4.74958 a 9.8414697,2.6593676 0 0 0 -4.4142,-0.28577 z"
+       id="path2056-0" />
+  </g>
+</svg>


### PR DESCRIPTION
These will eventually be used for IndoorNav. Since we don't have a dedicated Husky Observer description package anymore, this is the closest analogue for where to put these images